### PR TITLE
bugfix: PSISAT change of sign error introduced with v4.0 groundwater updates

### DIFF
--- a/HRLDAS/phys/module_sf_noahmpdrv.F
+++ b/HRLDAS/phys/module_sf_noahmpdrv.F
@@ -1538,7 +1538,7 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
 	      
               BEXP   =   BEXP_TABLE(ISLTYP(I,J))
               SMCMAX = SMCMAX_TABLE(ISLTYP(I,J))
-              PSISAT = -1.0*PSISAT_TABLE(ISLTYP(I,J))
+              PSISAT = PSISAT_TABLE(ISLTYP(I,J))
 
               DO NS=1, NSOIL
 	        IF ( SMOIS(I,NS,J) > SMCMAX )  SMOIS(I,NS,J) = SMCMAX


### PR DESCRIPTION
bugfix: PSISAT change of sign error introduced with v4.0 groundwater updates (d051018)