### PR TITLE
Define and declare a few variables in physics routines

### DIFF
--- a/HRLDAS/phys/module_sf_noahmp_glacier.F
+++ b/HRLDAS/phys/module_sf_noahmp_glacier.F
@@ -1004,6 +1004,7 @@ contains
         NITERB = 5
         MPE    = 1E-6
         DTG    = 0.
+        MOZ    = 0.
         MOZSGN = 0
         MOZOLD = 0.
         H      = 0.

--- a/HRLDAS/phys/module_sf_noahmpdrv.F
+++ b/HRLDAS/phys/module_sf_noahmpdrv.F
@@ -1252,7 +1252,9 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
 
   use module_sf_noahmplsm
   use noahmp_tables
-        
+
+  implicit none
+
   integer,                    intent(in   ) :: nsoil     ! number of soil layers
   real, dimension( 1:nsoil ), intent(inout) :: sand
   real, dimension( 1:nsoil ), intent(inout) :: clay
@@ -1268,6 +1270,7 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
   real, dimension( 1:nsoil ) :: psi_e
     
   type(noahmp_parameters), intent(inout) :: parameters
+  integer :: k
 
   do k = 1,4
     if(sand(k) <= 0 .or. clay(k) <= 0) then

--- a/HRLDAS/phys/module_sf_noahmplsm.F
+++ b/HRLDAS/phys/module_sf_noahmplsm.F
@@ -1776,6 +1776,7 @@ ENDIF   ! CROPTYPE == 0
     CHLEAF    = 0.
     CHUC      = 0.
     CHV2      = 0.
+    RB        = 0.
 
 ! wind speed at reference height: ur >= 1
 


### PR DESCRIPTION
A few variables were not defined properly in the Noah-MP-4.0.1
physics routines.  These were revealed by using the Intel 18
compiler with strict checks during the integration of the LSM
into the Land Information System (LIS) software framework.

- Variable MOZ was not initialized in subroutine GLACIER_FLUX,
  which calls subroutine SFCDIF1_GLACIER.  In this routine,
  MOZOLD is set to the value of MOZ, and later on, MOZOLD is
  multiplied by a new value of MOZ.  In the land physics,
  MOZ is set to zero before the call to subroutine SFCDIF1;
  this initialization was followed in the glacier physics.

- In subroutine ENERGY, variable RB is declared to be an
  output variable; however, it was not set in the routine.

- In subroutine PEDOTRANSFER_SR2006, the variable k was not
  declared to be an integer.

Resolves: #15